### PR TITLE
enhancement

### DIFF
--- a/create-lx-image
+++ b/create-lx-image
@@ -164,7 +164,7 @@ create_dataset() {
 
 install_tar() {
 	echo "==> Installing the tar archive, this will take a few minutes..."
-	( cd "$zroot" && gtar --strip-components=$(tar tzf $TARBALL | grep '/root/' | awk -F"/" '{print NF-2}') "-x$gtaropts" "$TARBALL" )
+	( cd "$zroot" && gtar --strip-components="$(tar tzf $TARBALL | grep '/root/' | awk -F"/" '{print NF-2}')" "-x$gtaropts" "$TARBALL" )
 	if [[ "$?" -ne "0" ]] ; then
 		echo "==> Error: extraction from tar archive failed."
 		zfs destroy -r zones/$IUUID

--- a/create-lx-image
+++ b/create-lx-image
@@ -164,8 +164,7 @@ create_dataset() {
 
 install_tar() {
 	echo "==> Installing the tar archive, this will take a few minutes..."
-	( cd "$zroot" && gtar --strip-components="$(tar tzf $TARBALL | grep '/root/' | awk -F"/" '{print NF-2}')" "-x$gtaropts" "$TARBALL" )
-	if [[ "$?" -ne "0" ]] ; then
+	if ! ( cd "$zroot" && gtar --strip-components="$(tar tzf $TARBALL | grep '/root/' | awk -F"/" '{print NF-2}')" "-x$gtaropts" "$TARBALL" ); then
 		echo "==> Error: extraction from tar archive failed."
 		zfs destroy -r zones/$IUUID
 	fi

--- a/create-lx-image
+++ b/create-lx-image
@@ -130,13 +130,13 @@ IUUID=${IMAGE_NAME}-$BUILD_DATE
 filetype=$({ LC_ALL=C file $TARBALL | awk '{print $2}' ; } 2>/dev/null)
 
 if [[ "$filetype" = "gzip" ]]; then
-	gtaropts="-xz"
+	gtaropts="z"
 elif [[ "$filetype" = "bzip2" ]]; then
-	gtaropts="-xj"
+	gtaropts="j"
 elif [[ "$filetype" = "compressed" ]]; then
-	gtaropts="-xZ"
+	gtaropts="Z"
 elif [[ "$filetype" = "USTAR" ]]; then
-	gtaropts="-x"
+	gtaropts=""
 else
 	printf "==> ERROR: must be a gzip, bzip2, .Z or uncompressed tar archive"
 	exit 1
@@ -164,7 +164,7 @@ create_dataset() {
 
 install_tar() {
 	echo "==> Installing the tar archive, this will take a few minutes..."
-	( cd "$zroot" && gtar --strip-components=2 "$gtaropts" "$TARBALL" )
+	( cd "$zroot" && gtar --strip-components=$(tar tzf $TARBALL | grep '/root/' | awk -F"/" '{print NF-2}') "-x$gtaropts" "$TARBALL" )
 	if [[ "$?" -ne "0" ]] ; then
 		echo "==> Error: extraction from tar archive failed."
 		zfs destroy -r zones/$IUUID

--- a/install
+++ b/install
@@ -249,7 +249,7 @@ ln -s ../bin/busybox init
 popd
 
 echo "==> Making /usr/bin/su symlink relative"
-rm $INSTALL_DIR/usr/bin/su
+[ -e $INSTALL_DIR/usr/bin/su ] && rm $INSTALL_DIR/usr/bin/su
 pushd $PWD
 cd $INSTALL_DIR/usr/bin/
 ln -s ../../bin/bbsuid ./su
@@ -286,7 +286,12 @@ echo "====> Running ./install.sh -i $INSTALL_DIR"
 )
 
 echo "==> Saving installation as $TARGET. This may take a few minutes."
-tar czf $TARGET --exclude-from=exclude.txt $INSTALL_DIR/
+umount $INSTALL_DIR/proc
+umount $INSTALL_DIR/sys
+tar czf $TARGET $(eval echo $(sed -e 's/^/--exclude=$INSTALL_DIR\//g' exclude.txt | sed -e 's/exclude=\//exclude=/g' | tr '\n' ' ')) $INSTALL_DIR/
+
+echo "==> Cleanup chroot $INSTALL_DIR"
+rm -rf $INSTALL_DIR
 
 echo "==> Installation complete!"
 echo "==> $TARGET"

--- a/install
+++ b/install
@@ -288,10 +288,9 @@ echo "====> Running ./install.sh -i $INSTALL_DIR"
 echo "==> Saving installation as $TARGET. This may take a few minutes."
 umount $INSTALL_DIR/proc
 umount $INSTALL_DIR/sys
-tar czf $TARGET $(eval echo $(sed -e 's/^/--exclude=$INSTALL_DIR\//g' exclude.txt | sed -e 's/exclude=\//exclude=/g' | tr '\n' ' ')) $INSTALL_DIR/
-
-echo "==> Cleanup chroot $INSTALL_DIR"
-rm -rf $INSTALL_DIR
+ESCAPED_INSTALL_DIR="$(echo "$INSTALL_DIR/" | sed -e 's/\//\\\//g')"
+EXCLUDE="$(sed -e s/^/--exclude=$ESCAPED_INSTALL_DIR/g exclude.txt | sed -e 's/exclude=\//exclude=/g' | tr '\n' ' '))"
+tar czf $TARGET $EXCLUDE $INSTALL_DIR/
 
 echo "==> Installation complete!"
 echo "==> $TARGET"


### PR DESCRIPTION
Hi,

had some issues while building a new alpine lx zone image based on version 3.7

**install script to create tarball:**

Fix for alpien 3.7 where /usr/bin/su is not existing when trying to remove $INSTALL_DIR/usr/bin/su
so fist check if it exist

log showed 
```
==> Making /usr/bin/su symlink relative
rm: cannot remove '/tmp/alpine/usr/bin/su': No such file or directory
```

the the exclude patterns in the exclude.txt used could potentially contain path that holds the entire chroot dir. For example if you use /tmp/xyz to build the tarball.
-> added dynamically created --exclude options based on the exclude.txt but dynamically adding the $INSTALL_DIR

```
# /install -r 3.7 -a apk-tools-static-2.8.2-r0.apk -d /tmp/alpine -m http://mirrors.gigenet.com/alpinelinux -i alpine-3 -p "Alpine Linux" -D "Alpine 3.7.0 64-bit lx-brand image." -u https://docs.joyent.com/images/container-native-linux
==> Installing Alpine into /tmp/alpine
...
==> Installation complete!
==> alpine-3-20180209.tar.gz
# ls -lth
total 52K
-rw-r----- 1 root    root      45 Feb  9 19:39 alpine-3-20180209.tar.gz

# tar tzvf alpine-3-20180209.tar.gz 
#
```

**create-lx-image script:**

as your can use any path as chroot in the install script the --strip-components=2 could potentially be the wrong amount of components to strip. So determinate the amount automatically

hope the contributions are helpful

regards
Joeri